### PR TITLE
Update network_cabling_guidelines.adoc

### DIFF
--- a/networking/network_cabling_guidelines.adoc
+++ b/networking/network_cabling_guidelines.adoc
@@ -36,6 +36,6 @@ You should follow certain guidelines when cabling network connections:
 One network is for management, one is for data access, and one is for intracluster communication. The management and data networks can be logically separated.
 * You can have more than one data network connection to each node for improving the client (data) traffic flow.
 * A cluster can be created without data network connections, but it must include a cluster interconnect connection.
-* There should always be two cluster connections to each node, but nodes on FAS22xx systems can be configured with a single 10-GbE cluster port.
+* There should always be two or more cluster connections to each node.
 
 For more information on network cabling, see the http://docs.netapp.com/platstor/index.jsp[AFF and FAS System Documentation Center^] and the https://hwu.netapp.com/Home/Index[Hardware Universe^].


### PR DESCRIPTION
FAS22xx is EOS as of this year and has not been supported in ONTAP since 9.1. We can remove any FAS22xx-specific verbiage from documentation, frankly.
I also add "or more" because some platform configurations use 4 or even 8 cluster LIFs (e.g. FAS9000 with 8 x 10GbE cluster interconnects).
Two would be the minimum for redundancy.