### PR TITLE
Moving "How firmware is updated during upgrade" one level up.

### DIFF
--- a/upgrade/sidebar.yml
+++ b/upgrade/sidebar.yml
@@ -21,8 +21,8 @@ entries:
           url: "/upgrade/task_verifying_cluster_upgrade_limits.html"
         - title: Current cluster activity
           url: "/upgrade/task_identifying_current_cluster_activity.html"
-      - title: How firmware is updated during upgrade
-        url: "/upgrade/concept_how_firmware_is_updated_during_upgrade.html"
+    - title: How firmware is updated during upgrade
+      url: "/upgrade/concept_how_firmware_is_updated_during_upgrade.html"
   - title: What should I verify before I upgrade?
     url: "/upgrade/task_what_to_check_before_upgrade.html"
     entries:


### PR DESCRIPTION
Moving "How firmware is updated during upgrade" one level up as currently it is nested below "Without Upgrade Advisor".