### PR TITLE
Update disable-encryption-by-default-97-higher-task.adoc

### DIFF
--- a/encryption-at-rest/disable-encryption-by-default-97-higher-task.adoc
+++ b/encryption-at-rest/disable-encryption-by-default-97-higher-task.adoc
@@ -9,7 +9,7 @@ summary: "Beginning with ONTAP 9.7, aggregate and volume encryption is enabled b
 :imagesdir: ../media/
 
 [.lead]
-Beginning with ONTAP 9.7, aggregate and volume encryption is enabled by default if you have a volume encryption (VE) license and use an onboard or external key manager. You can disable encryption by default if required.
+Beginning with ONTAP 9.7, aggregate and volume encryption is enabled by default if you have a volume encryption (VE) license and use an onboard or external key manager. You can disable encryption by default for the entire cluster, if required.
 
 .What you'll need
 
@@ -17,8 +17,7 @@ You must be a cluster administrator to perform this task, or an SVM administrato
 
 .Step
 
-. To disable encryption by default in ONTAP 9.7 or later, run the following command:
+. To disable encryption by default for the entire cluster in ONTAP 9.7 or later, run the following command:
 +
-`options -option-name encryption.data_at_rest_encryption.disable_by_default -vserver (vservername or * for all) -option-value on`
+`options -option-name encryption.data_at_rest_encryption.disable_by_default -option-value on`
 +
-For complete command syntax, see the man page for the command.


### PR DESCRIPTION
The -vserver attribute in the command is not used by "options".
I clarified that this option applies globally - across the entire cluster.
I also removed the "see the man page" sentence, because the "options" CLI command is a hidden (!) command. There is no man page for "options". 

Historical commentary: The "options" command was somewhat ported over to GX/cluster-mode from its 7-Mode CLI origin, but there was a strong sentiment to discourage its existence in clustershell. So it was decided to hide it.  Unfortunately, some teams (like NVE/NAE folks) thought it was a good idea to use it for controlling the default. Arrgh.