### PR TITLE
Update configure_lif_service_policies.adoc

### DIFF
--- a/networking/configure_lif_service_policies.adoc
+++ b/networking/configure_lif_service_policies.adoc
@@ -22,7 +22,7 @@ summary: Create and assign a service policy for LIFs
 [.lead]
 You can configure LIF service policies to identify a single service or a list of services that will use a LIF.
 
-== Create a service policy for LIFs
+== Create a service policy for LIFs(in advance/diag privilege)
 
 You can create a service policy for LIFs. You can assign a service policy to one or more LIFs; thereby allowing the LIF to carry traffic for a single service or a list of services.
 


### PR DESCRIPTION
please modify below content in line 25:

Create a service policy for LIFs

to

Create a service policy for LIFs(in advanced/diag privilege).

the command "network interface service-policy create" can not running in admin privilege:

cluster2::> network interface service-policy ?
  show                        Display existing service policies

cluster2::*> set diag

Warning: These diagnostic commands are for use by NetApp personnel only.
Do you want to continue? {y|n}: y

cluster2::*> network interface service-policy ?
  add-service                 *Add an additional service entry to an existing service policy
  clone                       *Clone an existing network service policy
  create                      *Create a new service policy
  delete                      *Delete an existing service policy
  modify-service              *Modify a service entry in an existing service policy
  remove-service              *Remove a service entry from an existing service policy
  rename                      *Rename an existing network service policy
  restore-defaults            *Restore default settings to a service policy
  show                        Display existing service policies


