### PR TITLE
remove 9.8 in the ONTAP Release/License table

### DIFF
--- a/anti-ransomware/index.adoc
+++ b/anti-ransomware/index.adoc
@@ -25,7 +25,7 @@ The anti-ransomware feature is enabled with the following licenses.
 | ONTAP releases| License
 a| ONTAP 9.11.1 and later
 a| Anti-ransomware
-a| ONTAP 9.8-9.10.1
+a| ONTAP 9.10.1
 a| Multi-Tenant Key Management (MTKM)
 |===
 


### PR DESCRIPTION
It leads IMHO to some confusion with mentioning ONTAP 9.8 in the table. In ONTAP 9.8 and 9.9 is this feature not available.