### PR TITLE
SnapLock volumes typo

### DIFF
--- a/anti-ransomware/use-cases-restrictions-concept.adoc
+++ b/anti-ransomware/use-cases-restrictions-concept.adoc
@@ -70,7 +70,6 @@ Unsupported volume types:
 
 * offline volumes
 * restricted volumes
-* Snaplock volumes
 * SnapLock volumes
 * FlexGroup volumes
 * FlexCache volumes (the anti-ransomware feature is supported on origin FlexVol volumes but not on cache volumes)


### PR DESCRIPTION
In the section *Unsupported volume types* `* Snaplock volumes` is mentioned two times