### PR TITLE
Update support-storage-encryption-concept.adoc

### DIFF
--- a/encryption-at-rest/support-storage-encryption-concept.adoc
+++ b/encryption-at-rest/support-storage-encryption-concept.adoc
@@ -30,7 +30,7 @@ If an HA pair is using encrypting SAS or NVMe drives (SED, NSE, FIPS), you must 
 Two types of self-encrypting drive are supported:
 
 * Self-encrypting FIPS-certified SAS or NVMe drives are supported on all FAS and AFF systems. These drives, called _FIPS drives,_ conform to the requirements of Federal Information Processing Standard Publication 140-2, level 2. The certified capabilities enable protections in addition to encryption, such as preventing denial-of-service attacks on the drive. FIPS drives cannot be mixed with other types of drives on the same node or HA pair.
-* Beginning with ONTAP 9.6, self-encrypting NVMe drives that have not undergone FIPS testing are supported on AFF A800 and A320 systems. These drives, called _SEDs,_ offer the same encryption capabilities as FIPS drives, but can be mixed with non-SEDs on the same node or HA pair.
+* Beginning with ONTAP 9.6, self-encrypting NVMe drives that have not undergone FIPS testing are supported on AFF A800, A320 systems and later systems. These drives, called _SEDs,_ offer the same encryption capabilities as FIPS drives, but can be mixed with non-SEDs on the same node or HA pair.
 
 == When to use KMIP servers
 


### PR DESCRIPTION
Add wording to clarify that non FIPS drives that are SED are supported on newer systems than AFF A800 and A320.