### PR TITLE
# is allowed from ONTAP 9.11.1

### DIFF
--- a/smb-admin/add-list-netbios-aliases-server-task.adoc
+++ b/smb-admin/add-list-netbios-aliases-server-task.adoc
@@ -17,7 +17,7 @@ If you want SMB clients to connect to the SMB server by using an alias, you can 
 * You can configure up to 200 NetBIOS aliases on the SMB server.
 * The following characters are not allowed:
 +
-@  # *  (   ) = + [ ] | ; : " , < > \ / ?
+@  *  (   ) = + [ ] | ; : " , < > \ / ?
 
 .Steps
 


### PR DESCRIPTION
From ONTAP 9.11.1,  # is allowed as NetBIOS alias name. Please check it and reflect in this document.