### PR TITLE
Replace outdated parameter

### DIFF
--- a/san-admin/configure-svm-iscsi-task.adoc
+++ b/san-admin/configure-svm-iscsi-task.adoc
@@ -57,7 +57,7 @@ Configure an storage VM for iSCSI with the ONTAP CLI.
 `vserver iscsi create -vserver _vserver_name_ -target-alias _vserver_name_`
 . Create a LIF for the SVMs on each node to use for iSCSI:
 +
-`network interface create -vserver _vserver_name_ -lif _lif_name_ -role data -data-protocol iscsi -home-node _node_name_ -home-port _port_name_ -address _ip_address_ -netmask netmask`
+`network interface create -vserver _vserver_name_ -lif _lif_name_ -data-protocol iscsi -service-policy default-data-iscsi -home-node _node_name_ -home-port _port_name_ -address _ip_address_ -netmask netmask`
 . Verify that you set up your LIFs correctly:
 +
 `network interface show -vserver _vserver_name_`


### PR DESCRIPTION
The "role" parameter for network interfaces doesn't exist anymore and seems to have been replaced by "service-policy"