### PR TITLE
update auditing-events-concept for nfs4acl usage

### DIFF
--- a/nas-audit/auditing-events-concept.adoc
+++ b/nas-audit/auditing-events-concept.adoc
@@ -33,6 +33,6 @@ Although you can enable central access policy staging in the auditing configurat
 
 == NFS events
 
-You can audit file and directory NFSv4 access events on objects stored on SVMs.
+You can audit file and directory events by utilizing NFSv4 ACL's on objects stored on SVMs.
 
 // 4 FEB 2022, BURT 1451789 


### PR DESCRIPTION
Previously this line looked like we only audit nfsv4 access events.  This isnt the case.  we utilize nfsv4 acls, however all operations will be audited.  including cifs and nfs3.