### PR TITLE
Corrected formatting and added vserver parameter

### DIFF
--- a/data-protection/enable-disable-snapshot-dir-access-task.adoc
+++ b/data-protection/enable-disable-snapshot-dir-access-task.adoc
@@ -15,7 +15,7 @@ To determine whether the Snapshot copy directory is visible to NFS and SMB clien
 
 . Check the Snapshot directory access status:
 +
- `volume show -vserver _SVM_name_ -volume _vol_name_ -fields snapdir-access`
+`volume show -vserver _SVM_name_ -volume _vol_name_ -fields snapdir-access`
 +
 Example:
 +
@@ -28,13 +28,13 @@ vs0     vol1   false
 ----
 . Enable or disable the Snapshot copy directory access:
 +
-`volume modify -volume _vol_name_ -snapdir-access true|false`
+`volume modify -vserver _SVM_name_ -volume _vol_name_ -snapdir-access true|false`
 +
 The following example enables Snapshot copy directory access on vol1:
 +
 ----
 
-clus1::> volume modify -volume vol1 -snapdir-access true
+clus1::> volume modify -vserver vs0 -volume vol1 -snapdir-access true
 Volume modify successful on volume vol1 of Vserver vs0.
 ----
 


### PR DESCRIPTION
- Correcting the formatting for the first command in bullet 1 (leading space that caused it to not format as code and show the backticks (`) instead)
- Added the "-vserver" argument to the commands in bullet 2 to ensure that the properly volume is acted on (already there in bullet 1 and matches the outputs)