### PR TITLE
Removed extra formatting characters

### DIFF
--- a/data-protection/snapmirror-svm-replication-concept.adoc
+++ b/data-protection/snapmirror-svm-replication-concept.adoc
@@ -180,7 +180,7 @@ Not supported with SVM DR.
 
 == Configurations replicated in SVM DR relationships
 
-The following table shows the interaction of the `snapmirror create `-identity-preserve` option and the `snapmirror policy create` -discard-configs network` option:
+The following table shows the interaction of the `snapmirror create -identity-preserve` option and the `snapmirror policy create -discard-configs network` option:
 [cols="5*"]
 |===
 


### PR DESCRIPTION
Since the characters `` was placed incorrectly, the formatting of the commands stopped before it should. Removing the extra characters impoves readability.