### PR TITLE
Removes extra backticks in terminal output

### DIFF
--- a/mediator/manage-task.adoc
+++ b/mediator/manage-task.adoc
@@ -228,9 +228,9 @@ To manually install SCST, you need the SCST tar bundle that is used for the inst
 .. Determine each file name for "scst_vdisk", "scst", and "iscsi_scst" modules. 
 +
 ....
-`[root@localhost ~]# modinfo -n scst_vdisk`
-`[root@localhost ~]# modinfo -n scst`
-`[root@localhost ~]# modinfo -n iscst_scst_vdisk`
+[root@localhost ~]# modinfo -n scst_vdisk
+[root@localhost ~]# modinfo -n scst
+[root@localhost ~]# modinfo -n iscst_scst_vdisk
 ....
 
 .. Determine the kernel release.


### PR DESCRIPTION
In the section `Manually install SCST to perform host maintenance`, 2a, there are extra backticks showing in the console output that should not be there.