### PR TITLE
Update task_verifying_the_lif_failover_configuration.adoc

### DIFF
--- a/upgrade/task_verifying_the_lif_failover_configuration.adoc
+++ b/upgrade/task_verifying_the_lif_failover_configuration.adoc
@@ -22,7 +22,7 @@ If you have less than 8 nodes in your cluster, the automated upgrade is performe
 [cols=2*,options="header"]
 |===
 |If your ONTAP version is... | Use this command
-|9.6 or later a| `network interface show -service-policy data -failover`
+|9.6 or later a| `network interface show -service-policy \*data* -failover`
 |9.5 or earlier a| `network interface show -role data -failover`
 |===
 +


### PR DESCRIPTION
Need to add wildcards to the -service-policy argument - in ONTAP 9.8 the policies are all <something>-data-<something>.

I assume this would match if on 9.6/9.7 the service policy still just uses "data" as the name there but I no longer have any clusters running those versions to test on.