### PR TITLE
Requirement: "All nodes in the destination cluster must be running the same ONTAP version"

### DIFF
--- a/svm-migrate/index.adoc
+++ b/svm-migrate/index.adoc
@@ -72,6 +72,7 @@ link:https://review.docs.netapp.com/us-en/ontap_main/peering/create-cluster-rela
 * The source and destination clusters must have the Data Protection Bundle license installed
 * All nodes in the source cluster must be running ONTAP 9.10.1 or later
 * All nodes in the source cluster must be running the same ONTAP version
+* All nodes in the destination cluster must be running the same ONTAP version
 * The destination cluster must be at the same or newer effective cluster version (ECV) as the source cluster
 * The source and destination clusters must support the same IP subnet for data LIF access
 * The network connecting the source and destination clusters must have a maximum round trip time (RTT) of less than 10ms


### PR DESCRIPTION
Added the following to the requirements:

"All nodes in the destination cluster must be running the same ONTAP version"

Before it only specified source cluster requirements, but this also applies to the destination cluster.