### PR TITLE
Update install-mediator-pkg-task.adoc

### DIFF
--- a/mediator/install-mediator-pkg-task.adoc
+++ b/mediator/install-mediator-pkg-task.adoc
@@ -12,22 +12,6 @@ summary: "To install the ONTAP Mediator service, you must  get the installation 
 [.lead]
 To install the ONTAP Mediator service, you must  get the installation package and run the installer on the host.
 
-.About this task
-
-* Beginning with ONTAP Mediator 1.4, the Secure Boot mechanism is enabled on UEFI systems. When Secure Boot is enabled, you must take additional steps to register the security key after installation:
-         
-** Follow instructions in the README file to sign the SCST kernel module.:
-+
-`/opt/netapp/lib/ontap_mediator/ontap_mediator/SCST_mod_keys/README.module-signing`
-
-** Locate the required keys: 
-+
-`/opt/netapp/lib/ontap_mediator/ontap_mediator/SCST_mod_keys`
-
-+
-NOTE: After installation, the README files and key location are also provided in the system output.
-
-
 .Steps
 
 . Run the installer and respond to the prompts as required: 
@@ -42,6 +26,18 @@ NOTE: After installation, the README files and key location are also provided in
 The installation process proceeds to create the required accounts and install required packages. If you have a previous version of Mediator installed on the host, you will be prompted to confirm that you want to upgrade.
 +
 
+. Beginning with ONTAP Mediator 1.4, the Secure Boot mechanism is enabled on UEFI systems. When Secure Boot is enabled, you must take additional steps to register the security key after installation:
+         
+** Follow instructions in the README file to sign the SCST kernel module.:
++
+`/opt/netapp/lib/ontap_mediator/ontap_mediator/SCST_mod_keys/README.module-signing`
+
+** Locate the required keys: 
++
+`/opt/netapp/lib/ontap_mediator/ontap_mediator/SCST_mod_keys`
+
++
+NOTE: After installation, the README files and key location are also provided in the system output.
 
 .Example of ONTAP Mediator 1.5 installation (console output)
 [%collapsible]


### PR DESCRIPTION
Field Support had a feedback about the User-Guide:

"Given that the UEFI setting can be a showstopper for installation, I recommend putting the information about UEFI within the steps itself in the docs page.

When the information is in the steps section, it illustrates that the information provided is needed in some fashion for a successful installation. Currently it is in the "About this task" section, which does not properly illustrate the full importance of the UEFI secure boot setting notice."

Hence, making a change to move the "About this task" content as Step 2.