### PR TITLE
Update convert-snapmirror-version-flexible-task.adoc

### DIFF
--- a/data-protection/convert-snapmirror-version-flexible-task.adoc
+++ b/data-protection/convert-snapmirror-version-flexible-task.adoc
@@ -27,7 +27,7 @@ After you convert a SnapMirror relationship type from DP to XDP, space-related s
 +
 [source,cli]
 ----
-snapmirror show -destination-path _SVM:volume_|_cluster://SVM/volume_
+snapmirror show -destination-path SVM:volume
 ----
 +
 The following example shows the output from the `snapmirror show` command:
@@ -63,7 +63,7 @@ You might find it helpful to retain a copy of the `snapmirror show` command outp
 +
 [source,cli]
 ----
-volume snapshot show -vserver _SVM_ -volume _volume_
+volume snapshot show -vserver SVM -volume volume
 ----
 +
 The following example shows the `volume snapshot show` output for the souce and the destination volumes:
@@ -111,7 +111,7 @@ snapmirror.10af643c-32d1-11e3-954b-123478563412_2147484682.2014-06-27_100026
 +
 [source,cli]
 ----
-snapmirror quiesce -source-path _SVM:volume_|_cluster://SVM/volume_, ... -destination-path _SVM:volume_|_cluster://SVM/volume_, ...
+snapmirror quiesce -source-path SVM:volume -destination-path SVM:volume
 ----
 +
 For complete command syntax, see the link:https://docs.netapp.com/us-en/ontap-cli-9131//snapmirror-quiesce.html[man page^].
@@ -131,7 +131,7 @@ cluster_dst::> snapmirror quiesce -destination-path svm_backup:volA_dst
 +
 [source, cli]
 ----
-snapmirror break -destination-path _SVM:volume_|_cluster://SVM/volume_, ...
+snapmirror break -destination-path SVM:volume
 ----
 +
 For complete command syntax, see the link:https://docs.netapp.com/us-en/ontap-cli-9131//snapmirror-break.html[man page^].
@@ -161,7 +161,7 @@ cluster_dst::> volume snapshot autodelete modify -vserver svm_backup -volume vol
 +
 [source,cli]
 ----
-snapmirror delete -destination-path _SVM:volume_|_cluster://SVM/volume_, ...
+snapmirror delete -destination-path SVM:volume
 ----
 +
 For complete command syntax, see the link:https://docs.netapp.com/us-en/ontap-cli-9131//snapmirror-delete.html[man page^].
@@ -181,7 +181,7 @@ cluster_dst::> snapmirror delete -destination-path svm_backup:volA_dst
 +
 [source,cli]
 ----
-snapmirror create -source-path _SVM:volume_|_cluster://SVM/volume_, ... -destination-path _SVM:volume_|_cluster://SVM/volume_, ... -type XDP -schedule _schedule_ -policy _policy_
+snapmirror create -source-path SVM:volume -destination-path SVM:volume -type XDP -schedule schedule -policy policy
 ----
 +
 The new relationship must use the same source and destination volume. For complete command syntax, see the man page.
@@ -202,7 +202,7 @@ cluster_dst::> snapmirror create -source-path svm1:volA -destination-path svm_ba
 +
 [source,cli]
 ----
-snapmirror resync -source-path _SVM:volume_|_cluster://SVM/volume_, ... -destination-path _SVM:volume_|_cluster://SVM/volume_, ...
+snapmirror resync -source-path SVM:volume -destination-path SVM:volume
 ----
 +
 
@@ -222,7 +222,7 @@ cluster_dst::> snapmirror resync -source-path svm1:volA -destination-path svm_ba
 
 . If you disabled automatic deletion of Snapshot copies, reenable it:
 +
-[source, cli]
+[source]
 ----
 volume snapshot autodelete modify -vserver _SVM_ -volume _volume_ -enabled true
 ----


### PR DESCRIPTION
A customer was badly confused by the cli syntax examples in the published doc:

snapmirror show -destination-path _SVM:volume_|_cluster://SVM/volume_

The pipe separator is used in the CLI reference as well as the command line to denote -or- examples.  In this context, we only use SVM name and volume name.  The example after the pipe is for pre-8.2 relationships like LS Mirror, and has no purpose in the context of DP to XDP conversion.

Additionally, there seems to be a syntax error, prepending and appending underscore to the strings in the syntax example.

The customer encountered an error during an attempted conversion and opened a support case as a result.  The error also led the customer to locate a KB article about errors during DP to XDP conversion, where they also tried to apply the bad syntax.

Once the customer had a remote session with support, and the bad syntax was explained, the steps in the docs as well as steps in the KB article worked.

Please make corrections that align with the simplified SVM:volume examples provided in my edit.