### PR TITLE
Update control-domain-controller-discovery-task.adoc

### DIFF
--- a/smb-admin/control-domain-controller-discovery-task.adoc
+++ b/smb-admin/control-domain-controller-discovery-task.adoc
@@ -20,7 +20,7 @@ In ONTAP 9.3 and later releases, the `discovery-mode` parameter of the `cifs dom
 * All DCs in the domain are discovered.
 * Only DCs in the local site are discovered.
 +
-The `default-site` parameter for the SMB server must be defined to use this mode.
+The `default-site` parameter for the SMB server can be defined to use this mode with lifs that are not assigned to a site in sites-and-services.
 
 * Server discovery is not performed, the SMB server configuration depends only on preferred DCs.
 +


### PR DESCRIPTION
default-site is only needed if sites-and-services in AD is not configured for our lifs

removed 'must' requirement 