### PR TITLE
Update configure_dns_for_host-name_resolution.adoc

### DIFF
--- a/networking/configure_dns_for_host-name_resolution.adoc
+++ b/networking/configure_dns_for_host-name_resolution.adoc
@@ -43,17 +43,17 @@ See xref:configure_dynamic_dns_services.html[Configure dynamic DNS services] for
 . Enable DNS on the SVM:
 +
 ....
-vserver services name-service dns create -vserver vserver_name -domains domain_name - name-servers ip_addresses -state enabled
+vserver services name-service dns create -vserver <vserver_name> -domains <domain_name> -name-servers <ip_addresses> -state enabled
 ....
 +
 The following command enables external DNS server servers on the SVM vs1:
 +
 ....
-vserver services name-service dns create -vserver <vs1.example.com> -domains <example.com> -name-servers <192.0.2.201,192.0.2.202> -state <enabled>
+vserver services name-service dns create -vserver vs1.example.com -domains example.com -name-servers 192.0.2.201,192.0.2.202 -state enabled
 ....
 +
 [NOTE]
-The vserver services name-service dns create command performs an automatic configuration validation and reports an error message if ONTAP cannot contact the name server.
+The `vserver services name-service dns create` command performs an automatic configuration validation and reports an error message if ONTAP cannot contact the name server.
 
 //. Enable DNS on LIFs owned by the SVM:
 //+
@@ -76,10 +76,13 @@ The vserver services name-service dns create command performs an automatic confi
 +
 ....
 vserver services name-service dns check -vserver vs1.example.com
-VserverName       Server     Status    Status Details
-----------------  ---------- -------   --------------------------
-vs1.example.com   10.0.0.50  up        Response time (msec): 2
-vs1.example.com   10.0.0.51  up        Response time (msec): 2
+                              Name Server
+Vserver       Name Server     Status       Status Details
+------------- --------------- ------------ --------------------------
+vs1.example.com               up           Response time (msec): 2
+              10.0.0.50
+vs1.example.com               up           Response time (msec): 2
+              10.0.0.51
 ....
 
 For information about service policies that relate to DNS, see link:lifs_and_service_policies96.html[LIFs and service policies in ONTAP 9.6 and later].
@@ -97,19 +100,19 @@ You must have decided which name service to use for host mapping in your environ
 . Add the necessary entries to the name service switch table:
 +
 ....
-vserver services name-service <ns-switch> create -vserver <vserver_name> -database <database_name> -source <source_names>
+vserver services name-service ns-switch modify -vserver <vserver_name> -database <database_name> -source <source_names>
 ....
 
 . Verify that the name service switch table contains the expected entries in the desired order:
 +
 ....
-vserver services name-service <ns-switch> show -vserver <vserver_name>
+vserver services name-service ns-switch show -vserver <vserver_name>
 ....
 
 .Example
 
-The following example creates an entry in the name service switch table for SVM vs1 to first use the local hosts file and then an external DNS server to resolve host names:
+The following example modifies an entry in the name service switch table for SVM vs1 to first use the local hosts file and then an external DNS server to resolve host names:
 
 ....
-vserver services name-service ns-switch create -vserver vs1 -database hosts -sources files dns
+vserver services name-service ns-switch modify -vserver vs1 -database hosts -sources files,dns
 ....


### PR DESCRIPTION
* Removed unnecessary space in command
* Added "<" and ">" around placeholders in commands that were not present before
* Removed "<" and ">" in the command examples that should only be used for the placeholders
* Changed the wording referencing "creating" entries in NS-SWITCH as these are created when the SVM is created and have to be "modified" to the desired configuration.  Attempting to create the same database again, even with a different source list, results in an error for "Duplicate entry"
** Although the ability to create/delete databases in NS-SWITCH exists, it is not a common task.
** The "modify" option is preferred.  I don't actually know why the functionality even exists in ONTAP, but we can at least try to guide people to use the preferred method since it is one step instead of two steps.
* Other minor edits