### PR TITLE
Update create-nis-domain-config-task.adoc

### DIFF
--- a/nfs-config/create-nis-domain-config-task.adoc
+++ b/nfs-config/create-nis-domain-config-task.adoc
@@ -19,8 +19,6 @@ If you plan to use NIS for directory searches, the maps in your NIS servers cann
 
 .About this task
 
-You can create multiple NIS domains. However, you can only use one that is set to `active`.
-
 If your NIS database contains a `netgroup.byhost` map, ONTAP can use it for quicker searches. The `netgroup.byhost` and `netgroup` maps in the directory must be kept in sync at all times to avoid client access issues. Beginning with ONTAP 9.7, NIS `netgroup.byhost` entries can be cached using the `vserver services name-service nis-domain netgroup-database` commands.
 
 Using NIS for host name resolution is not supported.
@@ -29,7 +27,7 @@ Using NIS for host name resolution is not supported.
 
 . Create an NIS domain configuration:
 +
-`vserver services name-service nis-domain create -vserver vs1 -domain _domain_name_ -active true _-servers IP_addresses_`
+`vserver services name-service nis-domain create -vserver vs1 -domain _domain_name_ -nis-servers _IP_addresses_`
 +
 You can specify up to 10 NIS servers.
 +
@@ -44,11 +42,10 @@ Beginning with ONTAP 9.2, the field `-nis-servers` replaces the field `-servers`
 
 .Example
 
-The following command creates and makes an active NIS domain configuration for an NIS domain called nisdomain on the SVM named vs1 with an NIS server at IP address 192.0.2.180:
+The following command creates an NIS domain configuration for an NIS domain called `nisdomain` on the SVM named `vs1` with an NIS server at IP address 192.0.2.180:
 
 ----
-vs1::> vserver services name-service nis-domain create -vserver vs1
--domain nisdomain -active true -nis-servers 192.0.2.180
+vs1::> vserver services name-service nis-domain create -vserver vs1 -domain nisdomain -nis-servers 192.0.2.180
 ----
 
 // 08 DEC 2021, BURT 1430515


### PR DESCRIPTION
Only a single NIS domain is supported for an SVM at a time instead of multiple as previously stated in documentation, so correcting that to avoid confusion.  Removing references to the "-active" parameter since that was only used/supported when multiple configurations could exist.