### PR TITLE
Update setup-aws-s3-cloud-tier-task.adoc

### DIFF
--- a/fabricpool/setup-aws-s3-cloud-tier-task.adoc
+++ b/fabricpool/setup-aws-s3-cloud-tier-task.adoc
@@ -14,11 +14,11 @@ If you are running ONTAP 9.2 or later, you can set up Amazon S3 as the cloud tie
 .Considerations for using Amazon S3 with FabricPool
 
 * You might need a FabricPool license.
- ** Newly ordered AFF systems come with 10 TB of free capacity for using FabricPool.
+ 
 +
 If you need additional capacity on an AFF system, if you use Amazon S3 on a non-AFF system, or if you upgrade from an existing cluster, you need a link:../fabricpool/install-license-aws-azure-ibm-task.html[FabricPool license].
 +
-If you order FabricPool for the first time for an existing cluster, a FabricPool license with 10 TB of free capacity is available.
+
 * It is recommended that the LIF that ONTAP uses to connect with the Amazon S3 object server be on a 10 Gbps port.
 * On AFF and FAS systems and ONTAP Select, FabricPool supports the following Amazon S3 storage classes:
  ** Amazon S3 Standard
@@ -63,6 +63,7 @@ cluster1::> storage aggregate object-store config create -object-store-name my_c
 +
 The `storage aggregate object-store config modify` command enables you to modify the Amazon S3 configuration information for FabricPool.
 
+// 2024-Oct-9, removed 10TB free capacity, discontinued many years ago 
 // 2024-Mar-28, ONTAPDOC-1366
 // 2023-Nov-2, issue# 1162
 // 2023-july-25, issue# 1028


### PR DESCRIPTION
Removed text associated with 10TB free capacity. This promotion ended many years ago.

"Newly ordered AFF systems come with 10 TB of free capacity for using FabricPool."

"If you order FabricPool for the first time for an existing cluster, a FabricPool license with 10 TB of free capacity is available."