### PR TITLE
Fixes to the documentation of the "cloud write" feature

### DIFF
--- a/fabricpool/enable-disable-volume-cloud-write-task.adoc
+++ b/fabricpool/enable-disable-volume-cloud-write-task.adoc
@@ -12,7 +12,7 @@ summary: "Beginning with ONTAP 9.14.1, you can enable and disable cloud write mo
 
 Beginning with ONTAP 9.14.1, you can enable and disable writing directly to the cloud on a new or existing volume in a FabricPool to allow NFS clients to write data directly to the cloud without waiting for tiering scans. SMB clients still write to the performance tier in a cloud write enabled volume. Cloud-write mode is disabled by default.
 
-Having the ability to write directly to the cloud is helpful for cases like migrations, for example, where large amounts of data are transferred to a cluster than the cluster can support on the local tier. Without cloud-write mode, during a migration, smaller amounts of data are transferred, then tiered, then transferred and tiered again, until the migration is complete. Using cloud-write mode, this type of management is no longer required because the data is never transferred to the local tier.
+Having the ability to write directly to the cloud is helpful for cases like migrations, for example, where large amounts of data are transferred to a cluster than the cluster can support on the local tier. Without cloud write mode, during a migration, smaller amounts of data are transferred, then tiered, then transferred and tiered again, until the migration is complete. Using cloud write mode, this type of management is no longer required because the data is never transferred to the local tier.
 
 
 .Before you begin
@@ -33,7 +33,7 @@ Having the ability to write directly to the cloud is helpful for cases like migr
 ----
 set -privilege advanced
 ----
-. Create a volume and enable cloud-write mode:
+. Create a volume and enable cloud write mode:
 +
 [source,cli]
 ----
@@ -56,7 +56,7 @@ volume create -vserver vs1 -volume vol1 -is-cloud-write-enabled true -aggregate 
 ----
 set -privilege advanced
 ----
-. Modify a volume to enable cloud-write mode:
+. Modify a volume to enable cloud write mode:
 +
 [source,cli]
 ----
@@ -79,14 +79,14 @@ volume modify -vserver vs1 -volume vol1 -is-cloud-write-enabled true
 ----
 set -privilege advanced
 ----
-. Disable cloud-write mode on a volume:
+. Disable cloud write mode on a volume:
 +
 [source,cli]
 ----
 volume modify -vserver <svm name> -volume <volume name> -is-cloud-write-enabled false
 ----
 +
-The following example disables cloud-write on the volume named vol1:
+The following example disables cloud write on the volume named vol1:
 +
 ----
 volume modify -vserver vs1 -volume vol1 -is-cloud-write-enabled false

--- a/fabricpool/enable-disable-volume-cloud-write-task.adoc
+++ b/fabricpool/enable-disable-volume-cloud-write-task.adoc
@@ -37,13 +37,13 @@ set -privilege advanced
 +
 [source,cli]
 ----
-volume create -volume <volume name> -is-cloud-write-enabled <true|false> -aggregate <local tier name>
+volume create -vserver <svm name> -volume <volume name> -is-cloud-write-enabled <true|false> -aggregate <local tier name>
 ----
 +
 The following example creates a volume named vol1 with cloud write enabled on the FabricPool local tier (aggr1):
 +
 ----
-volume create -volume vol1 -is-cloud-write-enabled true -aggregate aggr1
+volume create -vserver vs1 -volume vol1 -is-cloud-write-enabled true -aggregate aggr1
 ----
 
 == Enable writing directly to the cloud on an existing volume
@@ -60,13 +60,13 @@ set -privilege advanced
 +
 [source,cli]
 ----
-volume modify -volume <volume name> -is-cloud-write-enabled <true|false> -aggregate <local tier name>
+volume modify -vserver <svm name> -volume <volume name> -is-cloud-write-enabled true
 ----
 +
-The following example modifies a volume named vol1 with cloud write enabled on the FabricPool local tier (aggr1):
+The following example modifies a volume named vol1 to enable cloud write:
 +
 ----
-volume modify -volume vol1 -is-cloud-write-enabled true -aggregate aggr1
+volume modify -vserver vs1 -volume vol1 -is-cloud-write-enabled true
 ----
 
 == Disable writing directly to the cloud on a volume
@@ -79,17 +79,17 @@ volume modify -volume vol1 -is-cloud-write-enabled true -aggregate aggr1
 ----
 set -privilege advanced
 ----
-. Disable cloud-write mode:
+. Disable cloud-write mode on a volume:
 +
 [source,cli]
 ----
-volume modify -volume <volume name> -is-cloud-write-enabled <true|false> -aggregate <aggregate name>
+volume modify -vserver <svm name> -volume <volume name> -is-cloud-write-enabled false
 ----
 +
-The following example creates a volume named vol1 with cloud write enabled:
+The following example disables cloud-write on the volume named vol1:
 +
 ----
-volume modify -volume vol1 -is-cloud-write-enabled false -aggregate aggr1
+volume modify -vserver vs1 -volume vol1 -is-cloud-write-enabled false
 ----
 
 


### PR DESCRIPTION
This PR fixes several issues with the "cloud write" documentation.

* The `volume modify` command does not take the `-aggregate` option. This is likely a copy/paste error from the `volume create` command further up.
* Both the `volume create` and `volume modify` commands require specifying an SVM name. Added `-vserver vs1` as with other documents everywhere
* Fixed copy/paste issues in worgin in the paragraphs above the `volume modify` commands which were also referencing the Aggregate
* Changed the generic parameter description `-is-cloud-write-enabled <true|false>` to either specify `true` or `false` directly in the commands that are supposed to enable/disable the feature. The generic command line in the "create volume" section should be left as-is

Also, in a second commit (to make it easier to drop/ignore those changes), all uses of the phrase "cloud write" vs "cloud-write" were unified to the one without hypen/dash, as suggested by the manual pages. If this is not desired (or if the term "cloud-write" should be used instead) let me know then I can change that

The one line change in the last line is some newline-at-eof issue that I was sadly not able to get rid of... 