### PR TITLE
add missing step

### DIFF
--- a/volumes/rehost-snapmirror-relationship-task.adoc
+++ b/volumes/rehost-snapmirror-relationship-task.adoc
@@ -54,6 +54,10 @@ You must not break the SnapMirror relationship; otherwise, the data protection c
 +
 Setting the `relationship-info-only` parameter to `true` removes the source relationship information without deleting the Snapshot copies.
 
+. Unmount the volume, if it is mounted:
++
+`volume unmount -vserver source_svm -volume vol_name`
+
 . Switch to the advanced privilege level:
 +
 `set -privilege advanced`


### PR DESCRIPTION
if the volume is mounted it has to be unmounted before proceeding. cifs/nfs are usually mounted