### PR TITLE
Update verify-domain-accounts-map-default-unix-user-task.adoc to fix formatting issues

### DIFF
--- a/smb-hyper-v-sql/verify-domain-accounts-map-default-unix-user-task.adoc
+++ b/smb-hyper-v-sql/verify-domain-accounts-map-default-unix-user-task.adoc
@@ -29,22 +29,22 @@ When you create a storage virtual machine (SVM), ONTAP automatically creates the
 +
 Generally, the default user is given the user name "`pcuser`" and must be assigned the UID of `65534`. The default group is generally given the group name "`pcuser`". The GID assigned to the group must be `65534`.
 
- .. Create the default group:
- +
- `*vserver services unix-group create -vserver _vserver_name_ -name pcuser -id 65534*`
- .. Create the default user and add the default user to the default group:
- +
- `*vserver services unix-user create -vserver _vserver_name_ -user pcuser -id 65534 -primary-gid 65534*`
- .. Verify that the default user and default group are configured correctly:
- +
- `*vserver services unix-user show -vserver _vserver_name_*`
- +
- `*vserver services unix-group show -vserver _vserver_name_ -members*`
+.. Create the default group:
++
+`*vserver services unix-group create -vserver _vserver_name_ -name pcuser -id 65534*`
+.. Create the default user and add the default user to the default group:
++
+`*vserver services unix-user create -vserver _vserver_name_ -user pcuser -id 65534 -primary-gid 65534*`
+.. Verify that the default user and default group are configured correctly:
++
+`*vserver services unix-user show -vserver _vserver_name_*`
++
+`*vserver services unix-group show -vserver _vserver_name_ -members*`
 
 . If the CIFS server's default user is not configured, perform the following:
  .. Configure the default user:
 +
-`*vserver cifs options modify -vserver *vserver_name* -default-unix-user pcuser*`
+`*vserver cifs options modify -vserver _vserver_name_ -default-unix-user pcuser*`
  .. Verify that the default UNIX user is configured correctly:
 +
 `*vserver cifs options show -vserver _vserver_name_*`
@@ -68,8 +68,6 @@ Vserver: vs1
   Read Grants Exec       : disabled
   Read Only Delete       : disabled
   WINS Servers           : -
-
-
 
 cluster1::> vserver services unix-user show
           User            User   Group  Full


### PR DESCRIPTION
Correcting the formatting for bullets 3 and 4, and reduced the white space between the first command output in the example and the second prompt/command to be consistent with the others (1 blank line between each)