### PR TITLE
Fix FIPS enable command syntax in documentation

### DIFF
--- a/networking/configure_network_security_using_federal_information_processing_standards_fips.adoc
+++ b/networking/configure_network_security_using_federal_information_processing_standards_fips.adoc
@@ -72,7 +72,7 @@ When FIPS is enabled, you cannot install or create a certificate with an RSA key
 
 . Enable FIPS:
 +
-`security config modify -is-fips-enabled true`
+`security config modify * -is-fips-enabled true`
 
 . When prompted to continue, enter `y`
 . Beginning with ONTAP 9.9.1, rebooting is not required. If you are running ONTAP 9.8 or earlier, manually reboot each node in the cluster one by one. 


### PR DESCRIPTION
You are just missing a '*' The example on this page is correct: https://docs.netapp.com/us-en/ontap-cli/security-config-modify.html