### PR TITLE
Update S3 Snapshots index.adoc to clarify FabricPool restrictions

### DIFF
--- a/s3-snapshots/index.adoc
+++ b/s3-snapshots/index.adoc
@@ -70,6 +70,7 @@ Note the following feature exclusions and scenarios in ONTAP 9.16.1:
 ** On NetApp Console
 ** On System Manager
 ** In ONTAP MetroCluster configurations
+* S3 snapshots are not recommended on buckets being used as a local or remote FabricPool capacity tier.
 
 // 2025-Sept-10, BLUEXPDOC-872
 // 2024-10-21 ONTAPDOC-2165


### PR DESCRIPTION
S3 Snapshots are not recommended on buckets being used for FabricPool.  Updated doc to clarify this recommendation.